### PR TITLE
feat: Gitlab merge request label handler

### DIFF
--- a/data/merge.go
+++ b/data/merge.go
@@ -6,6 +6,7 @@ package data
 type Merge struct {
 	Object_kind       string
 	Object_attributes Object_attributes
+	Changes           Changes `json:"changes"`
 }
 
 type Object_attributes struct {
@@ -37,4 +38,29 @@ type Branche struct {
 	Http_url         string
 	Visibility_level float64
 	Namespace        string
+}
+
+// Changes object shape from Gitlab payload
+type Changes struct {
+	Labels Labels `json:"labels"`
+}
+
+// Labels object shape from Gitlab payload
+type Labels struct {
+	Previous []Label `json:"previous"`
+	Current  []Label `json:"current"`
+}
+
+// Label object shape from Gitlab payload
+type Label struct {
+	ID          int64       `json:"id"`
+	Title       string      `json:"title"`
+	Color       string      `json:"color"`
+	ProjectID   interface{} `json:"project_id"`
+	CreatedAt   string      `json:"created_at"`
+	UpdatedAt   string      `json:"updated_at"`
+	Template    bool        `json:"template"`
+	Description string      `json:"description"`
+	Type        string      `json:"type"`
+	GroupID     int64       `json:"group_id"`
 }

--- a/workplace-incoming-hook.go
+++ b/workplace-incoming-hook.go
@@ -393,6 +393,38 @@ func MergeHandler(body string) {
 		// Message
 		message += "[MERGE REQUEST " + strings.ToUpper(j.Object_attributes.State) + "] " + n + "Target : *" + j.Object_attributes.Target.Name + "/" + j.Object_attributes.Target_branch + "* Source : *" + j.Object_attributes.Source.Name + "/" + j.Object_attributes.Source_branch + "* at *" + dateString + "* " + n // First line
 		message += "Description: " + MessageEncode(j.Object_attributes.Description)                                                                                                                                                                                                                                     // Third line (last commit message)
+
+		if len(j.Changes.Labels.Current) > 0 || len(j.Changes.Labels.Previous) > 0 {
+			message += n + " [LABELS] "
+			for _, currentLabel := range j.Changes.Labels.Current {
+				added := true
+				for _, previousLabel := range j.Changes.Labels.Previous {
+					if currentLabel.ID == previousLabel.ID {
+						added = false
+						break
+					}
+				}
+
+				if added {
+					message += n + "`" + currentLabel.Title + "`" + " " + "*Added*"
+				}
+			}
+
+			for _, previousLabel := range j.Changes.Labels.Previous {
+				removed := true
+				for _, currentLabel := range j.Changes.Labels.Current {
+					if previousLabel.ID == currentLabel.ID {
+						removed = false
+						break
+					}
+				}
+
+				if removed {
+					message += n + "`" + previousLabel.Title + "`" + " " + "*Removed*"
+				}
+			}
+		}
+
 		SendWorkchatMessage(ThreadGitlab, message, ChatType)
 	}
 }


### PR DESCRIPTION
Handle label changes inside `Merge Request` to be displayed properly

Ex:
![image](https://user-images.githubusercontent.com/11565866/54491133-81496d00-48ee-11e9-802d-f7bcad474749.png)
